### PR TITLE
Проверка логов действий для сборки apk

### DIFF
--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -49,9 +49,12 @@ jobs:
         # Переименовываем с версией и датой
         for file in *.apk; do
           newname="FinancialSuccess-v${{ steps.version.outputs.version }}-${{ steps.date.outputs.date }}-debug.apk"
-          mv "$file" "$newname"
-          echo "Renamed to: $newname"
-          
+          if [ "$file" != "$newname" ]; then
+            mv "$file" "$newname"
+            echo "Renamed to: $newname"
+          else
+            echo "No rename needed: $file == $newname"
+          fi
           # Создаем симлинк на latest
           ln -sf "$newname" "latest-debug.apk"
         done


### PR DESCRIPTION
Add a conditional check before renaming the APK file to prevent `mv` command failure when source and destination names are identical.