### PR TITLE
Where is the version stored?

### DIFF
--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Copy APK to releases folder
       run: |
         mkdir -p releases/debug
+        ls -la app/build/outputs/apk/debug/
         cp app/build/outputs/apk/debug/*.apk releases/debug/
         cd releases/debug
         # Переименовываем с версией и датой


### PR DESCRIPTION
Add `ls -la` to debug APK copy step in GitHub Actions workflow.

This change helps diagnose why the APK file is not being copied by displaying the contents of the source directory (`app/build/outputs/apk/debug/`) before the copy operation.