### PR TITLE
Fix Android resource linking errors

### DIFF
--- a/app/src/main/res/layout/item_skill.xml
+++ b/app/src/main/res/layout/item_skill.xml
@@ -39,13 +39,13 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="space_between">
+            android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/tvSkillBonus"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:text="+10000₽"
                 android:textSize="14sp"
                 android:textStyle="bold"


### PR DESCRIPTION
Fix Android resource linking error by replacing invalid `android:gravity` value with `layout_weight` in `item_skill.xml`.

The `space_between` value is not valid for `android:gravity` in a `LinearLayout`, which caused the build failure. `android:layout_weight="1"` on the first `TextView` achieves the same visual effect of pushing the second `TextView` to the right.