### PR TITLE
Fix code warnings and failing tests

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/GameActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/GameActivity.kt
@@ -337,7 +337,7 @@ class GameActivity : AppCompatActivity() {
             player.logIncome(
                 FinancialCategory.SALARY,
                 player.salary,
-                "Ежемесячная зарплата по профессии ${player.profession?.name}"
+                "Ежемесячная зарплата по профессии ${player.profession.name}"
             )
             
             updateUI()
@@ -680,7 +680,7 @@ class GameActivity : AppCompatActivity() {
         updatePlayerAvatar(player)
         
         // Обновляем профессию на экране
-        binding.tvProfession.text = "Профессия: ${player.profession?.name ?: "-"}"
+        binding.tvProfession.text = "Профессия: ${player.profession.name}"
         
         // Обновляем финансовую информацию
         binding.tvCash.text = "Наличные: ${currencyFormat.format(player.cash)}"
@@ -944,7 +944,7 @@ class GameActivity : AppCompatActivity() {
             }
             
             // Информация о рисках профессии
-            val professionRisks = ProfessionalRisks.getRisksForProfession(player.profession?.name ?: "")
+            val professionRisks = ProfessionalRisks.getRisksForProfession(player.profession.name)
             if (professionRisks.isNotEmpty()) {
                 append("⚠️ ВОЗМОЖНЫЕ РИСКИ ПРОФЕССИИ:\n")
                 professionRisks.forEach { risk ->
@@ -1055,7 +1055,7 @@ class GameActivity : AppCompatActivity() {
     }
     
     private fun updatePlayerAvatar(player: Player) {
-        val avatarResource = player.profession?.avatarResId ?: R.drawable.player_token
+        val avatarResource = player.profession.avatarResId
         try {
             binding.ivPlayerAvatar.setImageResource(avatarResource)
         } catch (e: Exception) {
@@ -1124,7 +1124,7 @@ class GameActivity : AppCompatActivity() {
     private fun showAgeStatistics() {
         val player = currentGameState?.player ?: return
         // Получаем статистику по социальной группе (по id профессии)
-        val averageLifeExpectancy = when (player.profession?.id) {
+        val averageLifeExpectancy = when (player.profession.id) {
             "doctor" -> 78
             "engineer" -> 75
             "teacher" -> 77
@@ -1133,7 +1133,7 @@ class GameActivity : AppCompatActivity() {
             "lawyer" -> 76
             else -> 75
         }
-        val socialGroup = when (player.profession?.id) {
+        val socialGroup = when (player.profession.id) {
             "doctor" -> "медицинских работников"
             "engineer" -> "инженеров"
             "teacher" -> "работников образования"

--- a/app/src/main/java/com/financialsuccess/game/GameActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/GameActivity.kt
@@ -173,12 +173,12 @@ class GameActivity : AppCompatActivity() {
         
         if (diceValue == dreamNumber) {
             // Попал на мечту!
-            if (player.cash >= (player.dream?.cost ?: return)) {
+            if (player.cash >= player.dream.cost) {
                 // Может купить мечту - победа!
                 showVictoryDialog()
             } else {
                 // Попал, но недостаточно денег
-                val needed = (player.dream?.cost ?: 0) - player.cash
+                val needed = player.dream.cost - player.cash
                 showMessage("🎯 Вы попали на свою мечту!\n\nОднако вам не хватает ${currencyFormat.format(needed)} для её покупки.\n\nПродолжайте инвестировать и накапливать деньги!")
                 
                 // Получаем денежный поток за ход

--- a/app/src/main/java/com/financialsuccess/game/GameActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/GameActivity.kt
@@ -167,7 +167,7 @@ class GameActivity : AppCompatActivity() {
     
     private fun handleFastTrackDice(diceValue: Int) {
         val player = currentGameState?.player ?: return
-        val dreamNumber = player.dream?.fastTrackNumber ?: return
+        val dreamNumber = player.dream.fastTrackNumber
         
         binding.tvDiceValue.text = "Результат: $diceValue (Нужно: ${dreamNumber})"
         
@@ -227,7 +227,7 @@ class GameActivity : AppCompatActivity() {
         
         AlertDialog.Builder(this)
             .setTitle("🎉 ПОБЕДА!")
-            .setMessage("Поздравляем! Вы достигли своей мечты: ${player.dream?.name ?: "неизвестная мечта"}!\n\nВы успешно вышли из крысиных бегов и осуществили финансовую мечту!\n\nИтоговый капитал: ${currencyFormat.format(player.cash)}\nПассивный доход: ${currencyFormat.format(player.passiveIncome)}")
+            .setMessage("Поздравляем! Вы достигли своей мечты: ${player.dream.name}!\n\nВы успешно вышли из крысиных бегов и осуществили финансовую мечту!\n\nИтоговый капитал: ${currencyFormat.format(player.cash)}\nПассивный доход: ${currencyFormat.format(player.passiveIncome)}")
             .setPositiveButton("🎊 Новая игра") { _, _ ->
                 // Перезапуск игры
                 finish()
@@ -245,7 +245,7 @@ class GameActivity : AppCompatActivity() {
         val message = """
             🏆 ФИНАЛЬНАЯ СТАТИСТИКА
             
-            🎯 Мечта: ${player.dream?.name ?: "неизвестная мечта"}
+            🎯 Мечта: ${player.dream.name}
             💰 Итоговый капитал: ${currencyFormat.format(player.cash)}
             📊 Пассивный доход: ${currencyFormat.format(player.passiveIncome)}
             🏠 Активов: ${player.assets.size}
@@ -781,7 +781,7 @@ class GameActivity : AppCompatActivity() {
         
         AlertDialog.Builder(this)
             .setTitle("🎉 Поздравляем!")
-            .setMessage("Ваш пассивный доход превысил расходы!\n\nВы можете выйти из крысиных бегов на скоростную дорожку!\n\n🎯 На скоростной дорожке:\n• Ваша цель: ${player.dream?.name ?: "неизвестная мечта"}\n• Нужно выбросить: ${player.dream?.fastTrackNumber ?: 6}\n• Стоимость мечты: ${currencyFormat.format(player.dream?.cost ?: 0)}\n• Вы получаете денежный поток каждый ход")
+            .setMessage("Ваш пассивный доход превысил расходы!\n\nВы можете выйти из крысиных бегов на скоростную дорожку!\n\n🎯 На скоростной дорожке:\n• Ваша цель: ${player.dream.name}\n• Нужно выбросить: ${player.dream.fastTrackNumber}\n• Стоимость мечты: ${currencyFormat.format(player.dream.cost)}\n• Вы получаете денежный поток каждый ход")
             .setPositiveButton("🚀 Перейти") { _, _ ->
                 currentGameState?.player?.isInFastTrack = true
                 updateUI()
@@ -796,7 +796,7 @@ class GameActivity : AppCompatActivity() {
         
         AlertDialog.Builder(this)
             .setTitle("🎯 Скоростная дорожка!")
-            .setMessage("Добро пожаловать на скоростную дорожку!\n\n🎲 Как играть:\n• Бросайте кубик каждый ход\n• Нужно выбросить ${player.dream?.fastTrackNumber ?: 6} для вашей мечты\n• При попадании вы можете купить мечту если хватает денег\n• Каждый ход вы получаете денежный поток\n• При 1 или 6 возможны бонусы!\n\n💰 Ваши деньги: ${currencyFormat.format(player.cash)}\n🎯 Нужно для мечты: ${currencyFormat.format(player.dream?.cost ?: 0)}")
+            .setMessage("Добро пожаловать на скоростную дорожку!\n\n🎲 Как играть:\n• Бросайте кубик каждый ход\n• Нужно выбросить ${player.dream.fastTrackNumber} для вашей мечты\n• При попадании вы можете купить мечту если хватает денег\n• Каждый ход вы получаете денежный поток\n• При 1 или 6 возможны бонусы!\n\n💰 Ваши деньги: ${currencyFormat.format(player.cash)}\n🎯 Нужно для мечты: ${currencyFormat.format(player.dream.cost)}")
             .setPositiveButton("🎮 Играть!", null)
             .show()
     }
@@ -1071,7 +1071,7 @@ class GameActivity : AppCompatActivity() {
         
         // Позиционируем игрока на треке (процент от 0 до 100)
         val progress = if (player.isInFastTrack) {
-            val dreamCost = player.dream?.cost ?: 1
+            val dreamCost = player.dream.cost
             ((player.cash.toFloat() / dreamCost.toFloat()) * 100).coerceAtMost(100f)
         } else {
             // Теперь используем день месяца (1..30)
@@ -1115,7 +1115,7 @@ class GameActivity : AppCompatActivity() {
         
         // Обновляем финиш/мечту
         binding.tvFinishGoal.text = if (player.isInFastTrack) {
-            "🎯\n${player.dream?.name ?: "Мечта"}"
+            "🎯\n${player.dream.name}"
         } else {
             "🔄\nКруг"
         }

--- a/app/src/main/java/com/financialsuccess/game/GameManager.kt
+++ b/app/src/main/java/com/financialsuccess/game/GameManager.kt
@@ -88,7 +88,7 @@ class GameManager {
             currentState.player.logIncome(
                 com.financialsuccess.game.models.FinancialCategory.SALARY,
                 currentState.player.salary,
-                "Ежемесячная зарплата по профессии ${currentState.player.profession?.name}"
+                "Ежемесячная зарплата по профессии ${currentState.player.profession.name}"
             )
             // Затем списываем ежемесячные расходы
             currentState.player.processMonthlyOperations()

--- a/app/src/main/java/com/financialsuccess/game/models/Player.kt
+++ b/app/src/main/java/com/financialsuccess/game/models/Player.kt
@@ -23,8 +23,8 @@ data class Player(
     var childrenExpenses: Int = 0,
     var taxes: Int = 0,
     var otherExpenses: Int = 0,
-    val profession: Profession? = null,
-    val dream: Dream? = null,
+    val profession: Profession,
+    val dream: Dream,
     val assets: MutableList<Asset> = mutableListOf(),
     val liabilities: MutableList<Liability> = mutableListOf(),
     val investments: MutableList<Investment> = mutableListOf(),
@@ -93,8 +93,8 @@ data class Player(
     
     fun updateTotalExpenses() {
         // Базовые расходы из профессии
-        val professionExpenses = profession?.expenses ?: 0
-        val professionTaxes = profession?.taxes ?: 0
+        val professionExpenses = profession.expenses
+        val professionTaxes = profession.taxes
         
         // Распределяем базовые расходы по категориям
         foodExpenses = (professionExpenses * 0.4).toInt()
@@ -326,7 +326,7 @@ data class Player(
      
      // Проверить профессиональные риски (вызывается каждый ход)
      fun checkProfessionalRisks() {
-         val profession = this.profession ?: return
+         val profession = this.profession
          val availableRisks = ProfessionalRisks.getRisksForProfession(profession.name)
          
          for (risk in availableRisks) {
@@ -473,7 +473,7 @@ data class Player(
      
      // Обновить зарплату с учетом всех бонусов
      fun updateSalaryWithBonuses() {
-         val baseSalary = profession?.salary ?: 0
+         val baseSalary = profession.salary
          val educationBonus = calculateEducationBonus()
          val skillsBonus = calculateSkillsBonus()
          

--- a/app/src/test/PlayerDateLogicTest.kt
+++ b/app/src/test/PlayerDateLogicTest.kt
@@ -5,10 +5,28 @@ import org.junit.Test
 
 class PlayerDateLogicTest {
     private lateinit var player: Player
+    private lateinit var profession: com.financialsuccess.game.models.Profession
+    private lateinit var dream: com.financialsuccess.game.models.Dream
 
     @Before
     fun setUp() {
-        player = Player()
+        profession = com.financialsuccess.game.models.Profession(
+            id = "test_prof",
+            name = "Тестовая профессия",
+            description = "desc",
+            salary = 1000,
+            expenses = 500,
+            taxes = 100,
+            education = ""
+        )
+        dream = com.financialsuccess.game.models.Dream(
+            id = "test_dream",
+            name = "Тестовая мечта",
+            description = "desc",
+            cost = 10000,
+            cashFlowRequired = 1000
+        )
+        player = Player(profession = profession, dream = dream)
     }
 
     @Test
@@ -52,7 +70,7 @@ class PlayerDateLogicTest {
     fun testPlayerNameAndStartDate() {
         val name = "Алексей"
         val startDate = 1717977600000L // 10.06.2024
-        val player = Player(name = name, startDateMillis = startDate)
+        val player = Player(name = name, startDateMillis = startDate, profession = profession, dream = dream)
         assertEquals(name, player.name)
         assertEquals(startDate, player.startDateMillis)
     }

--- a/app/src/test/PlayerTest.kt
+++ b/app/src/test/PlayerTest.kt
@@ -57,7 +57,18 @@ class PlayerTest {
     
     @Test
     fun `test player initialization with default values`() {
-        val defaultPlayer = Player()
+        val defaultProfession = Profession(
+            name = "Default",
+            salary = 0,
+            expenses = 0,
+            taxes = 0
+        )
+        val defaultDream = Dream(
+            name = "Default",
+            cost = 0,
+            description = ""
+        )
+        val defaultPlayer = Player(profession = defaultProfession, dream = defaultDream)
         
         assertEquals(25, defaultPlayer.age)
         assertEquals(0, defaultPlayer.cash)


### PR DESCRIPTION
Make Player's profession and dream non-nullable to enforce business logic and remove redundant null checks.

This change resolves compilation warnings and test failures by ensuring that Player objects are always initialized with valid Profession and Dream instances, reflecting the game's rule that a player always has both.