### PR TITLE
Fix Android emulator setup issues

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -209,7 +209,7 @@ jobs:
       with:
         api-level: 30
         target: google_apis
-        arch: x86_64
+        arch: arm64-v8a
         profile: Nexus 6
         script: |
           adb shell input keyevent 82
@@ -272,7 +272,7 @@ jobs:
       with:
         api-level: 30
         target: google_apis
-        arch: x86_64
+        arch: arm64-v8a
         profile: Nexus 10
         script: |
           adb shell input keyevent 82


### PR DESCRIPTION
Switch Android emulator architecture to `arm64-v8a` to fix startup issues on GitHub Actions.

The `x86_64` emulator frequently failed to start and connect via ADB on GitHub Actions runners because KVM (hardware acceleration) is unavailable. Switching to `arm64-v8a` ensures stable emulator operation without KVM.