### PR TITLE
Resolve Android emulator architecture compatibility issue

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORname: 🚀 Stable Build & Release
+name: 🚀 Stable Build & Release
 
 on:
   push:
@@ -209,7 +209,7 @@ jobs:
       with:
         api-level: 30
         target: google_apis
-        arch: arm64-v8a
+        arch: x86_64
         profile: Nexus 6
         script: |
           adb shell input keyevent 82
@@ -272,7 +272,7 @@ jobs:
       with:
         api-level: 30
         target: google_apis
-        arch: arm64-v8a
+        arch: x86_64
         profile: Nexus 10
         script: |
           adb shell input keyevent 82


### PR DESCRIPTION
Update Android emulator architecture to x86_64 in CI workflow to resolve build failures on x86_64 hosts.

The `stable-build.yml` workflow was incorrectly configured to use `arm64-v8a` for the Android emulator, which is not supported on x86_64 host machines for API level 28+ and recent emulator versions. This issue was previously fixed in commit `efd0d82` but seems to have been reverted. This PR re-applies the correct `x86_64` architecture to ensure emulator compatibility and stable builds.