### PR TITLE
Set up GitHub CLI and run stable build

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -242,7 +242,7 @@ jobs:
           adb shell input keyevent 82
           sleep 5
 
-    - name: � Debug: Check environment after phone emulator start
+    - name: Debug: Check environment after phone emulator start
       run: |
         echo "=== Current directory ==="
         pwd
@@ -255,7 +255,7 @@ jobs:
         echo "=== APK files ==="
         ls -la releases/debug/ 2>/dev/null || echo "No releases/debug directory"
 
-    - name: � Install APK on Phone Emulator
+    - name: Install APK on Phone Emulator
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"
         adb install releases/debug/*.apk

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -1,4 +1,4 @@
-name: 🚀 Stable Build & Release
+name: Stable Build & Release
 
 on:
   push:

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -220,13 +220,11 @@ jobs:
         which adb
         adb version
 
-    - name: 🎭 Install Maestro
+    - name: Install Maestro
       run: |
         curl -Ls "https://get.maestro.mobile.dev" | bash
         export PATH="$PATH":"$HOME/.maestro/bin"
         echo "n" | maestro --version
-
-
 
     - name: Start Android Emulator (Phone)
       uses: reactivecircus/android-emulator-runner@v2
@@ -262,7 +260,7 @@ jobs:
         adb shell pm list packages | grep financialsuccess
         sleep 3
 
-    - name: 📸 Run Maestro Screenshots (Phone)
+    - name: Run Maestro Screenshots (Phone)
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"
         mkdir -p screenshots/phone
@@ -278,7 +276,7 @@ jobs:
         
         echo "📱 Phone screenshots completed!"
 
-    - name: 📤 Upload Phone Screenshots
+    - name: Upload Phone Screenshots
       uses: actions/upload-artifact@v4
       with:
         name: phone-screenshots-v${{ needs.build-and-test.outputs.version }}
@@ -321,7 +319,7 @@ jobs:
         which adb
         adb version
 
-    - name: 🎭 Install Maestro
+    - name: Install Maestro
       run: |
         curl -Ls "https://get.maestro.mobile.dev" | bash
         export PATH="$PATH":"$HOME/.maestro/bin"
@@ -343,7 +341,7 @@ jobs:
           adb shell input keyevent 82
           sleep 5
 
-    - name: 🔍 Debug: Check environment after tablet emulator start
+    - name: Debug: Check environment after tablet emulator start
       run: |
         echo "=== Current directory ==="
         pwd
@@ -356,14 +354,14 @@ jobs:
         echo "=== APK files ==="
         ls -la releases/debug/ 2>/dev/null || echo "No releases/debug directory"
 
-    - name: 📲 Install APK on Tablet Emulator
+    - name: Install APK on Tablet Emulator
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"
         adb install releases/debug/*.apk
         adb shell pm list packages | grep financialsuccess
         sleep 3
 
-    - name: 📸 Run Maestro Screenshots (Tablet)
+    - name: Run Maestro Screenshots (Tablet)
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"
         mkdir -p screenshots/tablet
@@ -379,7 +377,7 @@ jobs:
         
         echo "📱 Tablet screenshots completed!"
 
-    - name: 📤 Upload Tablet Screenshots
+    - name: Upload Tablet Screenshots
       uses: actions/upload-artifact@v4
       with:
         name: tablet-screenshots-v${{ needs.build-and-test.outputs.version }}

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -242,7 +242,20 @@ jobs:
           adb shell input keyevent 82
           sleep 5
 
-    - name: 📲 Install APK on Phone Emulator
+    - name: � Debug: Check environment after phone emulator start
+      run: |
+        echo "=== Current directory ==="
+        pwd
+        echo "=== Directory contents ==="
+        ls -la
+        echo "=== ADB devices ==="
+        adb devices
+        echo "=== Environment variables ==="
+        env | grep -E "(ANDROID|PATH|HOME)" | head -10
+        echo "=== APK files ==="
+        ls -la releases/debug/ 2>/dev/null || echo "No releases/debug directory"
+
+    - name: � Install APK on Phone Emulator
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"
         adb install releases/debug/*.apk
@@ -329,6 +342,19 @@ jobs:
           adb shell input keyevent 82
           adb shell input keyevent 82
           sleep 5
+
+    - name: 🔍 Debug: Check environment after tablet emulator start
+      run: |
+        echo "=== Current directory ==="
+        pwd
+        echo "=== Directory contents ==="
+        ls -la
+        echo "=== ADB devices ==="
+        adb devices
+        echo "=== Environment variables ==="
+        env | grep -E "(ANDROID|PATH|HOME)" | head -10
+        echo "=== APK files ==="
+        ls -la releases/debug/ 2>/dev/null || echo "No releases/debug directory"
 
     - name: 📲 Install APK on Tablet Emulator
       run: |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,18 @@
-## 🎮 Financial Success v1.45
+## 🎮 Financial Success v1.46
 
-### 📅 Дата релиза: 2025-07-12 18:24 UTC
+### 📅 Дата релиза: 2025-07-12 19:27 UTC
 
 ### 🔄 Последние изменения:
+0021473 🔖 Bump version to 1.46 (47) [auto]
+33177e3 Update stable-build.yml
+1c66d8b 📱 Auto-commit APK v1.45 - 2025-07-12_18-26
+058397b 📝 Update release notes [auto]
 48b01ce 🔖 Bump version to 1.45 (46) [auto]
 ef7832b Update README.md
 fa13b89 📱 Auto-commit APK v1.44 - 2025-07-12_18-23
 a6156c0 📝 Update release notes [auto]
 18f031f 🔖 Bump version to 1.44 (45) [auto]
 8faf9af Merge pull request #45 from RobotAvi/cursor/move-documentation-to-docs-folder-ff05
-2c5546f Remove GitHub Actions README with detailed workflow documentation
-dc8bf19 Remove unnecessary documentation files and update release notes
-f76324d 📱 Auto-commit APK v1.43 - 2025-07-12_18-07
-6ce8748 📝 Update release notes [auto]
 
 ### 📋 Изменения из CHANGELOG.md:
 ### 🔮 Планы на будущее

--- a/TRIGGER_BUILD.md
+++ b/TRIGGER_BUILD.md
@@ -1,0 +1,1 @@
+# Trigger stable build - Sat Jul 12 08:36:26 PM UTC 2025

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.financialsuccess.game"
         minSdk 24
         targetSdk 34
-        versionCode 46
-        versionName "1.45"
+        versionCode 47
+        versionName "1.46"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/releases/debug/latest-debug.apk
+++ b/releases/debug/latest-debug.apk
@@ -1,1 +1,1 @@
-FinancialSuccess-v1.45-2025-07-12_18-26-debug.apk
+FinancialSuccess-v1.46-2025-07-12_19-28-debug.apk


### PR DESCRIPTION
Fix YAML syntax errors in `stable-build.yml` by removing invalid characters and emojis from step names.

The workflow was failing with "Invalid workflow file" errors because GitHub's YAML parser could not handle non-standard characters (like `�` and `M-pM-^_M-^N`) and emojis present in the `name` fields of several steps. This PR replaces these with plain ASCII text to resolve the parsing issue and enable the workflow to run.