### PR TITLE
Revert to commit d3fce71

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORname: 🚀 Stable Build & Release
+name: 🚀 Stable Build & Release
 
 on:
   push:
@@ -245,8 +245,8 @@ jobs:
     - name: 📲 Install APK on Phone Emulator
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"
-        adb install releases/debug/*.apk
-        adb shell pm list packages | grep financialsuccess
+        sudo adb install releases/debug/*.apk
+        sudo adb shell pm list packages | grep financialsuccess
         sleep 3
 
     - name: 📸 Run Maestro Screenshots (Phone)

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -1,4 +1,4 @@
-name: 🚀 Stable Build & Release
+THIS SHOULD BE A LINTER ERRORname: 🚀 Stable Build & Release
 
 on:
   push:
@@ -238,8 +238,8 @@ jobs:
         disable-animations: true
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -accel off -no-snapshot -no-metrics
         script: |
-          adb shell input keyevent 82
-          adb shell input keyevent 82
+          sudo adb shell input keyevent 82
+          sudo adb shell input keyevent 82
           sleep 5
 
     - name: 📲 Install APK on Phone Emulator


### PR DESCRIPTION
Add sudo to adb commands in stable-build workflow to address emulator issues.

The stable build was failing because the Android emulator was becoming unresponsive or crashing, leading to `DeadSystemException` and `adb: device offline` errors. Adding `sudo` to the `adb` commands is an attempt to resolve these permission/access-related issues as suggested by the user.