### PR TITLE
Fix skill selection not working

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/CharacterCreationActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/CharacterCreationActivity.kt
@@ -217,14 +217,7 @@ class CharacterCreationActivity : AppCompatActivity() {
         
         // Навыки
         val skills = getAvailableSkills()
-        val skillAdapter = SkillAdapter(skills) { skill ->
-            if (selectedSkills.contains(skill)) {
-                selectedSkills.remove(skill)
-            } else {
-                if (selectedSkills.size < 3) { // Максимум 3 навыка
-                    selectedSkills.add(skill)
-                }
-            }
+        val skillAdapter = SkillAdapter(skills, selectedSkills) { skill ->
             // Уведомляем адаптер об изменениях
             (binding.recyclerViewSkills.adapter as? SkillAdapter)?.notifyDataSetChanged()
         }

--- a/app/src/main/java/com/financialsuccess/game/adapters/SkillAdapter.kt
+++ b/app/src/main/java/com/financialsuccess/game/adapters/SkillAdapter.kt
@@ -8,10 +8,9 @@ import com.financialsuccess.game.models.Skill
 
 class SkillAdapter(
     private val skills: List<Skill>,
+    private val selectedSkills: MutableList<Skill>,
     private val onSkillClick: (Skill) -> Unit
 ) : RecyclerView.Adapter<SkillAdapter.SkillViewHolder>() {
-
-    private val selectedSkills = mutableSetOf<Skill>()
 
     inner class SkillViewHolder(private val binding: ItemSkillBinding) : RecyclerView.ViewHolder(binding.root) {
         
@@ -49,6 +48,4 @@ class SkillAdapter(
     }
 
     override fun getItemCount(): Int = skills.size
-    
-    fun getSelectedSkills(): List<Skill> = selectedSkills.toList()
 }

--- a/app/src/main/res/drawable/skill_item_selector.xml
+++ b/app/src/main/res/drawable/skill_item_selector.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/primary_color_light" />
+            <stroke android:width="3dp" android:color="@color/primary_color" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/primary_color_light" />
+            <stroke android:width="2dp" android:color="@color/primary_color" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+            <stroke android:width="2dp" android:color="@color/primary_color" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/item_skill.xml
+++ b/app/src/main/res/layout/item_skill.xml
@@ -6,10 +6,9 @@
     android:layout_margin="8dp"
     app:cardCornerRadius="12dp"
     app:cardElevation="4dp"
-    app:strokeWidth="2dp"
-    app:strokeColor="@color/primary_color"
-    android:checkable="true"
-    android:checked="false">
+    android:background="@drawable/skill_item_selector"
+    android:clickable="true"
+    android:focusable="true">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- Primary Colors -->
     <color name="primary_color">#1976D2</color>
+    <color name="primary_color_light">#E3F2FD</color>
     <color name="primary_variant">#0D47A1</color>
     <color name="secondary_color">#FFC107</color>
     <color name="secondary_variant">#FF8F00</color>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix skill selection UI and logic in character creation to visually highlight selected skills and correctly manage the selection state.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation had two separate `selectedSkills` lists (one in the Activity, one in the Adapter), leading to desynchronization. Additionally, the `MaterialCardView` for skill items lacked a visual selector for its `selected` state, causing no visual feedback on click.