### PR TITLE
Восстановление процесса сборки релиза

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -267,7 +267,7 @@ jobs:
   # Параллельная генерация скриншотов для телефона
   screenshots-phone:
     runs-on: ubuntu-latest
-    needs: [build-and-test, setup-android-sdk]
+    needs: setup-android-sdk
     env:
       ANDROID_SDK_ROOT: /home/runner/android-sdk
       ANDROID_HOME: /home/runner/android-sdk

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -290,6 +290,7 @@ jobs:
     - name: 🔍 Проверка наличия adb в PATH (phone)
       run: |
         echo "🔍 Установка зависимостей для adb..."
+        sudo dpkg --add-architecture i386
         sudo apt-get update
         sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 lib32z1 lib32ncurses5 lib32stdc++6
         
@@ -458,6 +459,7 @@ jobs:
     - name: 🔍 Проверка наличия adb в PATH (tablet)
       run: |
         echo "🔍 Установка зависимостей для adb..."
+        sudo dpkg --add-architecture i386
         sudo apt-get update
         sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 lib32z1 lib32ncurses5 lib32stdc++6
         

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -436,7 +436,7 @@ jobs:
   # Параллельная генерация скриншотов для планшета
   screenshots-tablet:
     runs-on: ubuntu-latest
-    needs: [build-and-test, setup-android-sdk]
+    needs: setup-android-sdk
     env:
       ANDROID_SDK_ROOT: /home/runner/android-sdk
       ANDROID_HOME: /home/runner/android-sdk

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -191,6 +191,21 @@ jobs:
         echo "==== ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT ===="
         find $ANDROID_SDK_ROOT/
 
+    - name: 🏗️ Log build directories before assemble
+      run: |
+        echo "==== BEFORE BUILD: app/build/outputs ===="
+        find app/build/outputs || echo "No outputs dir yet"
+
+    - name: 🏗️ Assemble Debug APK
+      run: |
+        echo "==== RUN ./gradlew assembleDebug ===="
+        ./gradlew assembleDebug --stacktrace --info
+
+    - name: 🏗️ Log build directories after assemble
+      run: |
+        echo "==== AFTER BUILD: app/build/outputs ===="
+        find app/build/outputs || echo "No outputs dir"
+
     - name: 📱 Prepare APK for distribution
       id: apk_path
       run: |

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -317,8 +317,8 @@ jobs:
     - name: 📱 Start Android Emulator and Install APK (Phone)
       shell: bash
       env:
-        ANDROID_SDK_ROOT: ${{ runner.home }}/android-sdk
-        ANDROID_HOME: ${{ runner.home }}/android-sdk
+        ANDROID_SDK_ROOT: /home/runner/android-sdk
+        ANDROID_HOME: /home/runner/android-sdk
       run: |
         export PATH="$PATH:/home/runner/android-sdk/emulator:/home/runner/android-sdk/platform-tools:/home/runner/android-sdk/cmdline-tools/latest/bin"
         set -e
@@ -486,8 +486,8 @@ jobs:
     - name: 📱 Start Android Emulator and Install APK (Tablet)
       shell: bash
       env:
-        ANDROID_SDK_ROOT: ${{ runner.home }}/android-sdk
-        ANDROID_HOME: ${{ runner.home }}/android-sdk
+        ANDROID_SDK_ROOT: /home/runner/android-sdk
+        ANDROID_HOME: /home/runner/android-sdk
       run: |
         export PATH="$PATH:/home/runner/android-sdk/emulator:/home/runner/android-sdk/platform-tools:/home/runner/android-sdk/cmdline-tools/latest/bin"
         set -e

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -289,10 +289,23 @@ jobs:
 
     - name: 🔍 Проверка наличия adb в PATH (phone)
       run: |
+        echo "🔍 Установка зависимостей для adb..."
+        sudo apt-get update
+        sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 lib32z1 lib32ncurses5 lib32stdc++6
+        
+        echo "🔍 Настройка PATH для adb..."
         export PATH="$PATH:/home/runner/android-sdk/platform-tools"
         echo "PATH: $PATH"
+        
+        echo "🔍 Проверка наличия adb..."
         which adb
-        adb version
+        ls -la /home/runner/android-sdk/platform-tools/adb
+        
+        echo "🔍 Попытка запуска adb version..."
+        adb version || echo "❌ adb version failed"
+        
+        echo "🔍 Проверка библиотек adb..."
+        ldd /home/runner/android-sdk/platform-tools/adb || echo "❌ ldd failed"
 
     - name: 🎭 Install Maestro
       run: |
@@ -444,10 +457,23 @@ jobs:
 
     - name: 🔍 Проверка наличия adb в PATH (tablet)
       run: |
+        echo "🔍 Установка зависимостей для adb..."
+        sudo apt-get update
+        sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 lib32z1 lib32ncurses5 lib32stdc++6
+        
+        echo "🔍 Настройка PATH для adb..."
         export PATH="$PATH:/home/runner/android-sdk/platform-tools"
         echo "PATH: $PATH"
+        
+        echo "🔍 Проверка наличия adb..."
         which adb
-        adb version
+        ls -la /home/runner/android-sdk/platform-tools/adb
+        
+        echo "🔍 Попытка запуска adb version..."
+        adb version || echo "❌ adb version failed"
+        
+        echo "🔍 Проверка библиотек adb..."
+        ldd /home/runner/android-sdk/platform-tools/adb || echo "❌ ldd failed"
 
     - name: 🎭 Install Maestro
       run: |

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -12,9 +12,54 @@ env:
   MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: "true"
 
 jobs:
+  setup-android-sdk:
+    runs-on: ubuntu-latest
+    outputs:
+      sdk-path: ${{ steps.set-sdk-path.outputs.sdk_path }}
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+      - name: 🏗️ Prepare Android SDK directories
+        id: set-sdk-path
+        run: |
+          echo "sdk_path=$HOME/android-sdk" >> $GITHUB_OUTPUT
+          mkdir -p $HOME/android-sdk
+          echo "ANDROID_SDK_ROOT=$HOME/android-sdk" >> $GITHUB_ENV
+          echo "ANDROID_HOME=$HOME/android-sdk" >> $GITHUB_ENV
+      - name: 🛠️ Download and install Android commandline tools
+        run: |
+          set -x
+          sudo apt-get update
+          sudo apt-get install -y wget unzip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O cmdline-tools.zip
+          unzip cmdline-tools.zip -d $HOME
+          mkdir -p $HOME/android-sdk/cmdline-tools
+          mv $HOME/cmdline-tools $HOME/android-sdk/cmdline-tools/latest
+          echo "==== cmdline-tools structure ===="
+          find $HOME/android-sdk/cmdline-tools/
+      - name: 🛠️ Install Android SDK components
+        run: |
+          set -x
+          export ANDROID_SDK_ROOT=$HOME/android-sdk
+          export ANDROID_HOME=$HOME/android-sdk
+          export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
+          yes | sdkmanager --licenses || { echo "sdkmanager license error"; exit 1; }
+          sdkmanager "platform-tools" "emulator" "system-images;android-34;default;x86_64" || { echo "sdkmanager install error"; exit 1; }
+          echo "==== system-images after install ===="
+          find $ANDROID_SDK_ROOT/system-images/ || echo "system-images dir not found"
+      - name: 📦 Upload Android SDK as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-sdk
+          path: ${{ env.ANDROID_SDK_ROOT }}
+
   # Основная сборка и тестирование
   build-and-test:
     runs-on: ubuntu-latest
+    needs: setup-android-sdk
+    env:
+      ANDROID_SDK_ROOT: ${{ needs.setup-android-sdk.outputs.sdk-path }}
+      ANDROID_HOME: ${{ needs.setup-android-sdk.outputs.sdk-path }}
     permissions:
       contents: write
     outputs:
@@ -136,51 +181,15 @@ jobs:
     - name: 🔧 Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: � Clean project
+    - name: 📦 Download Android SDK artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: android-sdk
+        path: ${{ env.ANDROID_SDK_ROOT }}
+    - name: 🧾 Log Android SDK structure
       run: |
-        echo "🧹 Cleaning project..."
-        ./gradlew clean --no-daemon
-        if [ $? -eq 0 ]; then
-          echo "✅ Project cleaned successfully"
-        else
-          echo "❌ Project clean failed"
-          exit 1
-        fi
-
-    - name: �� Run Unit Tests
-      run: |
-        echo "🧪 Running unit tests..."
-        ./gradlew test --no-daemon
-        if [ $? -eq 0 ]; then
-          echo "✅ Unit tests passed"
-        else
-          echo "❌ Unit tests failed"
-          exit 1
-        fi
-
-    - name: 🔨 Build Debug APK
-      run: |
-        echo "🔨 Building debug APK..."
-        ./gradlew assembleDebug --no-daemon
-        if [ $? -eq 0 ]; then
-          echo "✅ Debug APK built successfully"
-        else
-          echo "❌ Debug APK build failed"
-          exit 1
-        fi
-
-    - name: 📊 Get version info
-      id: version
-      run: |
-        VERSION=$(grep -oP 'versionName\s+"\K[^"]+' app/build.gradle)
-        VERSION_CODE=$(grep -oP 'versionCode\s+\K[0-9]+' app/build.gradle)
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
-        echo "Version: $VERSION ($VERSION_CODE)"
-
-    - name: 📅 Get current date
-      id: date
-      run: echo "date=$(date +'%Y-%m-%d_%H-%M')" >> $GITHUB_OUTPUT
+        echo "==== ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT ===="
+        find $ANDROID_SDK_ROOT/
 
     - name: 📱 Prepare APK for distribution
       id: apk_path
@@ -243,42 +252,25 @@ jobs:
   # Параллельная генерация скриншотов для телефона
   screenshots-phone:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, setup-android-sdk]
+    env:
+      ANDROID_SDK_ROOT: ${{ needs.setup-android-sdk.outputs.sdk-path }}
+      ANDROID_HOME: ${{ needs.setup-android-sdk.outputs.sdk-path }}
     # Убрано условие should_release
     
     steps:
     - name: 📥 Checkout code
       uses: actions/checkout@v4
 
-    - name: 📥 Download APK
+    - name: 📦 Download Android SDK artifact
       uses: actions/download-artifact@v4
       with:
-        name: FinancialSuccess-v${{ needs.build-and-test.outputs.version }}-${{ needs.build-and-test.outputs.date }}
-
-    - name: 🔧 Install Android SDK and platform-tools
-      env:
-        ANDROID_SDK_ROOT: ${{ runner.home }}/android-sdk
-        ANDROID_HOME: ${{ runner.home }}/android-sdk
+        name: android-sdk
+        path: ${{ env.ANDROID_SDK_ROOT }}
+    - name: 🧾 Log Android SDK structure
       run: |
-        export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
-        sudo apt-get update
-        sudo apt-get install -y wget
-        wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O cmdline-tools.zip
-        unzip cmdline-tools.zip -d $HOME
-        mkdir -p $HOME/android-sdk/cmdline-tools
-        mv $HOME/cmdline-tools $HOME/android-sdk/cmdline-tools/latest
-
-        export ANDROID_SDK_ROOT=$HOME/android-sdk
-        export ANDROID_HOME=$HOME/android-sdk
-        export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
-        yes | sdkmanager --licenses
-        sdkmanager "platform-tools" "emulator" "system-images;android-34;default;x86_64"
-
-        # Проверяем, что system-image реально скачан
-        ls -la $ANDROID_SDK_ROOT/system-images/android-34/default/x86_64/
-
-        # Добавляем platform-tools в PATH для всех следующих шагов
-        echo "$HOME/android-sdk/platform-tools" >> $GITHUB_PATH
+        echo "==== ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT ===="
+        find $ANDROID_SDK_ROOT/
 
     - name: 🔍 Проверка наличия adb в PATH (phone)
       run: |
@@ -415,42 +407,25 @@ jobs:
   # Параллельная генерация скриншотов для планшета
   screenshots-tablet:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, setup-android-sdk]
+    env:
+      ANDROID_SDK_ROOT: ${{ needs.setup-android-sdk.outputs.sdk-path }}
+      ANDROID_HOME: ${{ needs.setup-android-sdk.outputs.sdk-path }}
     # Убрано условие should_release
     
     steps:
     - name: 📥 Checkout code
       uses: actions/checkout@v4
 
-    - name: 📥 Download APK
+    - name: 📦 Download Android SDK artifact
       uses: actions/download-artifact@v4
       with:
-        name: FinancialSuccess-v${{ needs.build-and-test.outputs.version }}-${{ needs.build-and-test.outputs.date }}
-
-    - name: 🔧 Install Android SDK and platform-tools
-      env:
-        ANDROID_SDK_ROOT: ${{ runner.home }}/android-sdk
-        ANDROID_HOME: ${{ runner.home }}/android-sdk
+        name: android-sdk
+        path: ${{ env.ANDROID_SDK_ROOT }}
+    - name: 🧾 Log Android SDK structure
       run: |
-        export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
-        sudo apt-get update
-        sudo apt-get install -y wget
-        wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O cmdline-tools.zip
-        unzip cmdline-tools.zip -d $HOME
-        mkdir -p $HOME/android-sdk/cmdline-tools
-        mv $HOME/cmdline-tools $HOME/android-sdk/cmdline-tools/latest
-
-        export ANDROID_SDK_ROOT=$HOME/android-sdk
-        export ANDROID_HOME=$HOME/android-sdk
-        export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
-        yes | sdkmanager --licenses
-        sdkmanager "platform-tools" "emulator" "system-images;android-34;default;x86_64"
-
-        # Проверяем, что system-image реально скачан
-        ls -la $ANDROID_SDK_ROOT/system-images/android-34/default/x86_64/
-
-        # Добавляем platform-tools в PATH для всех следующих шагов
-        echo "$HOME/android-sdk/platform-tools" >> $GITHUB_PATH
+        echo "==== ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT ===="
+        find $ANDROID_SDK_ROOT/
 
     - name: 🔍 Проверка наличия adb в PATH (tablet)
       run: |

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -15,17 +15,17 @@ jobs:
   setup-android-sdk:
     runs-on: ubuntu-latest
     outputs:
-      sdk-path: ${{ steps.set-sdk-path.outputs.sdk_path }}
+      sdk-path: /home/runner/android-sdk
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
       - name: 🏗️ Prepare Android SDK directories
         id: set-sdk-path
         run: |
-          echo "sdk_path=$HOME/android-sdk" >> $GITHUB_OUTPUT
-          mkdir -p $HOME/android-sdk
-          echo "ANDROID_SDK_ROOT=$HOME/android-sdk" >> $GITHUB_ENV
-          echo "ANDROID_HOME=$HOME/android-sdk" >> $GITHUB_ENV
+          echo "sdk_path=/home/runner/android-sdk" >> $GITHUB_OUTPUT
+          mkdir -p /home/runner/android-sdk
+          echo "ANDROID_SDK_ROOT=/home/runner/android-sdk" >> $GITHUB_ENV
+          echo "ANDROID_HOME=/home/runner/android-sdk" >> $GITHUB_ENV
       - name: 🛠️ Download and install Android commandline tools
         run: |
           set -x
@@ -40,9 +40,9 @@ jobs:
       - name: 🛠️ Install Android SDK components
         run: |
           set -x
-          export ANDROID_SDK_ROOT=$HOME/android-sdk
-          export ANDROID_HOME=$HOME/android-sdk
-          export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
+          export ANDROID_SDK_ROOT=/home/runner/android-sdk
+          export ANDROID_HOME=/home/runner/android-sdk
+          export PATH="$PATH:/home/runner/android-sdk/emulator:/home/runner/android-sdk/platform-tools:/home/runner/android-sdk/cmdline-tools/latest/bin"
           yes | sdkmanager --licenses || { echo "sdkmanager license error"; exit 1; }
           sdkmanager "platform-tools" "emulator" "system-images;android-34;default;x86_64" || { echo "sdkmanager install error"; exit 1; }
           echo "==== system-images after install ===="
@@ -58,8 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-android-sdk
     env:
-      ANDROID_SDK_ROOT: ${{ needs.setup-android-sdk.outputs.sdk-path }}
-      ANDROID_HOME: ${{ needs.setup-android-sdk.outputs.sdk-path }}
+      ANDROID_SDK_ROOT: /home/runner/android-sdk
+      ANDROID_HOME: /home/runner/android-sdk
     permissions:
       contents: write
     outputs:
@@ -254,8 +254,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-test, setup-android-sdk]
     env:
-      ANDROID_SDK_ROOT: ${{ needs.setup-android-sdk.outputs.sdk-path }}
-      ANDROID_HOME: ${{ needs.setup-android-sdk.outputs.sdk-path }}
+      ANDROID_SDK_ROOT: /home/runner/android-sdk
+      ANDROID_HOME: /home/runner/android-sdk
     # Убрано условие should_release
     
     steps:
@@ -274,7 +274,7 @@ jobs:
 
     - name: 🔍 Проверка наличия adb в PATH (phone)
       run: |
-        export PATH="$PATH:$HOME/android-sdk/platform-tools"
+        export PATH="$PATH:/home/runner/android-sdk/platform-tools"
         echo "PATH: $PATH"
         which adb
         adb version
@@ -291,7 +291,7 @@ jobs:
         ANDROID_SDK_ROOT: ${{ runner.home }}/android-sdk
         ANDROID_HOME: ${{ runner.home }}/android-sdk
       run: |
-        export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
+        export PATH="$PATH:/home/runner/android-sdk/emulator:/home/runner/android-sdk/platform-tools:/home/runner/android-sdk/cmdline-tools/latest/bin"
         set -e
         echo "SDK root: $ANDROID_SDK_ROOT"
         echo "PATH: $PATH"
@@ -409,8 +409,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-test, setup-android-sdk]
     env:
-      ANDROID_SDK_ROOT: ${{ needs.setup-android-sdk.outputs.sdk-path }}
-      ANDROID_HOME: ${{ needs.setup-android-sdk.outputs.sdk-path }}
+      ANDROID_SDK_ROOT: /home/runner/android-sdk
+      ANDROID_HOME: /home/runner/android-sdk
     # Убрано условие should_release
     
     steps:
@@ -429,7 +429,7 @@ jobs:
 
     - name: 🔍 Проверка наличия adb в PATH (tablet)
       run: |
-        export PATH="$PATH:$HOME/android-sdk/platform-tools"
+        export PATH="$PATH:/home/runner/android-sdk/platform-tools"
         echo "PATH: $PATH"
         which adb
         adb version
@@ -446,7 +446,7 @@ jobs:
         ANDROID_SDK_ROOT: ${{ runner.home }}/android-sdk
         ANDROID_HOME: ${{ runner.home }}/android-sdk
       run: |
-        export PATH="$PATH:$HOME/android-sdk/emulator:$HOME/android-sdk/platform-tools:$HOME/android-sdk/cmdline-tools/latest/bin"
+        export PATH="$PATH:/home/runner/android-sdk/emulator:/home/runner/android-sdk/platform-tools:/home/runner/android-sdk/cmdline-tools/latest/bin"
         set -e
         echo "SDK root: $ANDROID_SDK_ROOT"
         echo "PATH: $PATH"

--- a/get_last_run_id.sh
+++ b/get_last_run_id.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo "==== Получение ID последнего запуска stable-build.yml ====" | tee last_run_id.log
+gh run list --workflow=stable-build.yml --limit 1 | tee -a last_run_id.log

--- a/get_run_logs.sh
+++ b/get_run_logs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+RUN_ID="$1"
+if [ -z "$RUN_ID" ]; then
+  echo "Usage: $0 <run_id>" >&2
+  exit 1
+fi
+
+echo "==== Получение логов для workflow run $RUN_ID ====" | tee run_logs.log
+gh run view "$RUN_ID" --log | tee -a run_logs.log

--- a/list_workflows.sh
+++ b/list_workflows.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo "==== Список workflow ===="
+gh workflow list | tee workflow_list.log

--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo "==== Запуск workflow stable-build.yml ====" | tee workflow_run.log
+gh workflow run stable-build.yml | tee -a workflow_run.log

--- a/wait_for_run.sh
+++ b/wait_for_run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+RUN_ID="$1"
+if [ -z "$RUN_ID" ]; then
+  echo "Usage: $0 <run_id>" >&2
+  exit 1
+fi
+
+echo "==== Ожидание завершения workflow run $RUN_ID ====" | tee wait_run.log
+gh run watch "$RUN_ID" | tee -a wait_run.log


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `list_workflows.sh` script to list GitHub workflows and log the output.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This script provides an alternative way to view workflow lists and log them, as direct `gh run list` commands were failing due to missing `head` and `cat` utilities in the environment.