### PR TITLE
Fix game crash on start button

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/GameActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/GameActivity.kt
@@ -1069,8 +1069,8 @@ class GameActivity : AppCompatActivity() {
     
     private fun updateGameTrackVisualization(player: Player) {
         // Обновляем позицию игрока на треке
-        // Fix: Added proper imports for LinearLayout and ImageView
-        val trackLayout = binding.llGameTrack.getChildAt(1) as LinearLayout
+        // Fix: Используем binding.llTrackLine вместо getChildAt(1)
+        val trackLayout = binding.llTrackLine
         val playerIcon = trackLayout.findViewById<ImageView>(R.id.iv_player_on_track)
         
         // Позиционируем игрока на треке (процент от 0 до 100)


### PR DESCRIPTION
Use direct ViewBinding access for `llTrackLine` to fix `NullPointerException` on game start.

The original code `binding.llGameTrack.getChildAt(1) as LinearLayout` caused a `NullPointerException` because `llGameTrack` in `activity_game.xml` only contained one child at index 0 (`ll_track_line`). Accessing index 1 returned `null`, leading to a crash when casting. Using `binding.llTrackLine` directly leverages ViewBinding and correctly accesses the intended element, resolving the crash reported when pressing "Начать Игру".

---

[Open in Web](https://www.cursor.com/agents?id=bc-3a537362-f3cb-4efb-865b-414a4a75e57f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3a537362-f3cb-4efb-865b-414a4a75e57f)