### PR TITLE
fix: restore standard 5-step flow for 'New Game' button

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/MainActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/MainActivity.kt
@@ -28,6 +28,7 @@ class MainActivity : AppCompatActivity() {
         btnLoad.visibility = if (GameSaveManager.loadPlayer(this) != null) View.VISIBLE else View.GONE
 
         btnNew.setOnClickListener {
+            // Запуск только стандартного флоу (без custom)
             startActivity(Intent(this, CharacterCreationActivity::class.java))
         }
         btnLoad.setOnClickListener {


### PR DESCRIPTION
Теперь по кнопке 'Новая игра' запускается только стандартный флоу из пяти шагов, без кастомного создания персонажа. Кастомный флоу доступен только по кнопке 'Создать персонажа'.