### PR TITLE
Download android sdk artifact

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -112,8 +112,7 @@ jobs:
           
           echo "✅ Android SDK установлен и готов к использованию"
 
-      - name: 📦 Upload Android SDK as artifact (if not cached)
-        if: steps.cache-sdk-setup.outputs.cache-hit != 'true'
+      - name: 📦 Upload Android SDK as artifact
         uses: actions/upload-artifact@v4
         with:
           name: android-sdk
@@ -162,12 +161,14 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
           
-      - name: 📦 Download Android SDK artifact (if not cached)
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
+      - name: 📦 Download Android SDK artifact
+        id: download-sdk
         uses: actions/download-artifact@v4
         with:
           name: android-sdk
           path: /home/runner/android-sdk
+          
+
           
       - name: 🔧 Восстановление прав на выполнение (Build)
         run: |
@@ -306,8 +307,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-android-sdk-
 
-    - name: 📦 Download Android SDK artifact (if not cached)
-      if: steps.cache-sdk-screenshots.outputs.cache-hit != 'true'
+    - name: 📦 Download Android SDK artifact
       uses: actions/download-artifact@v4
       with:
         name: android-sdk


### PR DESCRIPTION
Fix GitHub Actions workflow to always upload and download Android SDK artifact, resolving "Artifact not found" errors.

The previous logic conditionally uploaded and downloaded the Android SDK artifact based on cache hits. This caused failures when the cache was hit in the upload job (no artifact uploaded), but subsequent jobs still attempted to download it (resulting in "Artifact not found"). This change ensures the artifact is consistently available.

---
<a href="https://cursor.com/background-agent?bcId=bc-d16e53fa-e0c6-4551-8d2f-4259b65db7cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d16e53fa-e0c6-4551-8d2f-4259b65db7cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>