### PR TITLE
Revert to specific commit

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -77,6 +77,9 @@ jobs:
           echo "🔧 ==== УСТАНОВКА ANDROID SDK (если не в кэше) ===="
           set -x
           
+          echo "🔧 Очистка существующих файлов..."
+          rm -rf $HOME/cmdline-tools.zip $HOME/cmdline-tools $HOME/android-sdk/cmdline-tools/latest
+          
           echo "🔧 Обновление пакетов..."
           sudo apt-get update
           
@@ -91,6 +94,13 @@ jobs:
           
           echo "🔧 Создание структуры директорий..."
           mkdir -p $HOME/android-sdk/cmdline-tools
+          
+          # Удаляем существующую директорию, если она есть
+          if [ -d "$HOME/android-sdk/cmdline-tools/latest" ]; then
+            echo "🔧 Удаление существующей директории latest..."
+            rm -rf $HOME/android-sdk/cmdline-tools/latest
+          fi
+          
           mv $HOME/cmdline-tools $HOME/android-sdk/cmdline-tools/latest
           
           echo "🔧 Настройка переменных окружения..."


### PR DESCRIPTION
Add cleanup steps to Android SDK setup in CI to fix build failures caused by existing directories.

The build was failing with `mv: cannot overwrite '/home/runner/cmdline-tools/latest/cmdline-tools': Directory not empty` during the Android SDK installation step. This PR resolves the issue by ensuring that target directories are removed before new files are moved into place, preventing conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-3588edf0-96f0-44c6-af40-0d714464d6b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3588edf0-96f0-44c6-af40-0d714464d6b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>