### PR TITLE
Fix emulator not found in cache

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -329,6 +329,85 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: 🗄️ Cache Android SDK and Emulator
+        id: cache-sdk-emulator
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.android/cache
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/avd
+            ${{ env.ANDROID_SDK_ROOT }}
+          key: ${{ runner.os }}-android-sdk-emulator-${{ hashFiles('**/build.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-android-sdk-emulator-
+            ${{ runner.os }}-android-sdk-
+
+      - name: 🛠️ Setup Android SDK (if not cached)
+        if: steps.cache-sdk-emulator.outputs.cache-hit != 'true'
+        run: |
+          echo "🔧 ==== УСТАНОВКА ANDROID SDK (если не в кэше) ===="
+          set -x
+          
+          # Проверяем, установлен ли уже SDK
+          if [ -d "$ANDROID_SDK_ROOT/cmdline-tools/latest" ] && [ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+            echo "✅ Android SDK уже установлен, пропускаем установку"
+            echo "🔧 Настройка переменных окружения..."
+            export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+          else
+            echo "🔧 Android SDK не найден, начинаем установку..."
+            
+            echo "🔧 Очистка существующих файлов..."
+            rm -rf $HOME/cmdline-tools.zip $HOME/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+            
+            echo "🔧 Обновление пакетов..."
+            sudo apt-get update
+            
+            echo "🔧 Установка wget и unzip..."
+            sudo apt-get install -y wget unzip
+            
+            echo "🔧 Загрузка commandline tools..."
+            wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O cmdline-tools.zip
+            
+            echo "🔧 Распаковка commandline tools..."
+            unzip cmdline-tools.zip -d $HOME
+            
+            echo "🔧 Создание структуры директорий..."
+            mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+            
+            # Удаляем существующую директорию, если она есть
+            if [ -d "$ANDROID_SDK_ROOT/cmdline-tools/latest" ]; then
+              echo "🔧 Удаление существующей директории latest..."
+              rm -rf $ANDROID_SDK_ROOT/cmdline-tools/latest
+            fi
+            
+            mv $HOME/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+            
+            echo "🔧 Настройка переменных окружения..."
+            export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+            
+            echo "🔧 Принятие лицензий..."
+            yes | sdkmanager --licenses || { echo "❌ ОШИБКА: sdkmanager license error"; exit 1; }
+            
+            echo "🔧 Установка компонентов SDK..."
+            yes | sdkmanager --install "platform-tools" "emulator" "system-images;android-34;google_apis;x86_64" || { echo "❌ ОШИБКА: sdkmanager install error"; exit 1; }
+            echo "🔧 Проверка установки компонентов..."
+            sdkmanager --list | grep -E "platform-tools|emulator|system-images;android-34" || { echo "❌ ОШИБКА: Компоненты не установлены"; exit 1; }
+            
+            echo "🔧 Установка прав на выполнение..."
+            sudo chmod -R +x $ANDROID_SDK_ROOT/platform-tools/ || echo "⚠️ Не удалось установить права для platform-tools"
+            sudo chmod -R +x $ANDROID_SDK_ROOT/emulator/ || echo "⚠️ Не удалось установить права для emulator"
+            sudo chmod -R +x $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/ || echo "⚠️ Не удалось установить права для cmdline-tools"
+            
+            echo "🔧 Проверка прав на выполнение..."
+            ls -la $ANDROID_SDK_ROOT/platform-tools/adb || echo "❌ adb не найден"
+            ls -la $ANDROID_SDK_ROOT/emulator/emulator || echo "❌ emulator не найден"
+            ls -la $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager || echo "❌ sdkmanager не найден"
+            
+            echo "✅ Android SDK установлен и готов к использованию"
+          fi
+
       - name: Настройка PATH для SDK
         run: |
           echo "🔧 ==== НАСТРОЙКА PATH ДЛЯ SDK ===="
@@ -343,6 +422,44 @@ jobs:
           # Проверяем доступность emulator
           echo "🔧 Проверка emulator:"
           emulator -version || echo "❌ emulator не найден"
+
+      - name: 🛠️ Установка эмулятора (если не в кэше)
+        if: steps.cache-sdk-emulator.outputs.cache-hit != 'true'
+        run: |
+          echo "🔧 ==== УСТАНОВКА ЭМУЛЯТОРА (ЕСЛИ НЕ В КЭШЕ) ===="
+          export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+          
+          echo "🔧 Проверка кэша эмулятора..."
+          if [ -d "~/.android/avd" ] && [ "$(ls -A ~/.android/avd/)" ]; then
+            echo "✅ Найден кэшированный AVD, пропускаем установку эмулятора"
+            echo "🔧 Проверка кэшированного эмулятора..."
+            ls -la $ANDROID_SDK_ROOT/emulator/emulator || echo "❌ emulator не найден"
+            avdmanager list avd || echo "⚠️ AVD не найдены"
+          else
+            echo "🔧 Кэш эмулятора не найден, устанавливаем..."
+            
+            echo "🔧 Проверка наличия эмулятора..."
+            if [ ! -f "$ANDROID_SDK_ROOT/emulator/emulator" ]; then
+              echo "🔧 Эмулятор не найден, устанавливаем..."
+              yes | sdkmanager --install "emulator" || { echo "❌ ОШИБКА: Установка эмулятора не удалась"; exit 1; }
+            fi
+            
+            echo "🔧 Проверка наличия system-image..."
+            if ! sdkmanager --list | grep -q "system-images;android-34"; then
+              echo "🔧 System image не найден, устанавливаем..."
+              yes | sdkmanager --install "system-images;android-34;google_apis;x86_64" || { echo "❌ ОШИБКА: Установка system-image не удалась"; exit 1; }
+            fi
+            
+            echo "🔧 Создание AVD для кэширования..."
+            echo "no" | avdmanager create avd -n "cached-emulator" -k "system-images;android-34;google_apis;x86_64" || echo "⚠️ Не удалось создать AVD"
+            
+            echo "🔧 Проверка установки..."
+            ls -la $ANDROID_SDK_ROOT/emulator/emulator || echo "❌ emulator не найден"
+            sdkmanager --list | grep -E "emulator|system-images;android-34" || echo "⚠️ Компоненты эмулятора не найдены в списке"
+            avdmanager list avd || echo "⚠️ AVD не найдены"
+            
+            echo "✅ Эмулятор установлен и готов к кэшированию"
+          fi
 
       - name: Проверка кэша эмулятора
         run: |
@@ -406,6 +523,108 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-android-sdk-emulator-
           ${{ runner.os }}-android-sdk-
+
+    - name: 🛠️ Setup Android SDK (if not cached)
+      if: steps.cache-sdk-screenshots.outputs.cache-hit != 'true'
+      run: |
+        echo "🔧 ==== УСТАНОВКА ANDROID SDK (если не в кэше) ===="
+        set -x
+        
+        # Проверяем, установлен ли уже SDK
+        if [ -d "$ANDROID_SDK_ROOT/cmdline-tools/latest" ] && [ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+          echo "✅ Android SDK уже установлен, пропускаем установку"
+          echo "🔧 Настройка переменных окружения..."
+          export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+        else
+          echo "🔧 Android SDK не найден, начинаем установку..."
+          
+          echo "🔧 Очистка существующих файлов..."
+          rm -rf $HOME/cmdline-tools.zip $HOME/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+          
+          echo "🔧 Обновление пакетов..."
+          sudo apt-get update
+          
+          echo "🔧 Установка wget и unzip..."
+          sudo apt-get install -y wget unzip
+          
+          echo "🔧 Загрузка commandline tools..."
+          wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O cmdline-tools.zip
+          
+          echo "🔧 Распаковка commandline tools..."
+          unzip cmdline-tools.zip -d $HOME
+          
+          echo "🔧 Создание структуры директорий..."
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+          
+          # Удаляем существующую директорию, если она есть
+          if [ -d "$ANDROID_SDK_ROOT/cmdline-tools/latest" ]; then
+            echo "🔧 Удаление существующей директории latest..."
+            rm -rf $ANDROID_SDK_ROOT/cmdline-tools/latest
+          fi
+          
+          mv $HOME/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+          
+          echo "🔧 Настройка переменных окружения..."
+          export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+          
+          echo "🔧 Принятие лицензий..."
+          yes | sdkmanager --licenses || { echo "❌ ОШИБКА: sdkmanager license error"; exit 1; }
+          
+          echo "🔧 Установка компонентов SDK..."
+          yes | sdkmanager --install "platform-tools" "emulator" "system-images;android-34;google_apis;x86_64" || { echo "❌ ОШИБКА: sdkmanager install error"; exit 1; }
+          echo "🔧 Проверка установки компонентов..."
+          sdkmanager --list | grep -E "platform-tools|emulator|system-images;android-34" || { echo "❌ ОШИБКА: Компоненты не установлены"; exit 1; }
+          
+          echo "🔧 Установка прав на выполнение..."
+          sudo chmod -R +x $ANDROID_SDK_ROOT/platform-tools/ || echo "⚠️ Не удалось установить права для platform-tools"
+          sudo chmod -R +x $ANDROID_SDK_ROOT/emulator/ || echo "⚠️ Не удалось установить права для emulator"
+          sudo chmod -R +x $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/ || echo "⚠️ Не удалось установить права для cmdline-tools"
+          
+          echo "🔧 Проверка прав на выполнение..."
+          ls -la $ANDROID_SDK_ROOT/platform-tools/adb || echo "❌ adb не найден"
+          ls -la $ANDROID_SDK_ROOT/emulator/emulator || echo "❌ emulator не найден"
+          ls -la $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager || echo "❌ sdkmanager не найден"
+          
+          echo "✅ Android SDK установлен и готов к использованию"
+        fi
+
+    - name: 🛠️ Установка эмулятора (если не в кэше)
+      if: steps.cache-sdk-screenshots.outputs.cache-hit != 'true'
+      run: |
+        echo "🔧 ==== УСТАНОВКА ЭМУЛЯТОРА (ЕСЛИ НЕ В КЭШЕ) ===="
+        export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+        
+        echo "🔧 Проверка кэша эмулятора..."
+        if [ -d "~/.android/avd" ] && [ "$(ls -A ~/.android/avd/)" ]; then
+          echo "✅ Найден кэшированный AVD, пропускаем установку эмулятора"
+          echo "🔧 Проверка кэшированного эмулятора..."
+          ls -la $ANDROID_SDK_ROOT/emulator/emulator || echo "❌ emulator не найден"
+          avdmanager list avd || echo "⚠️ AVD не найдены"
+        else
+          echo "🔧 Кэш эмулятора не найден, устанавливаем..."
+          
+          echo "🔧 Проверка наличия эмулятора..."
+          if [ ! -f "$ANDROID_SDK_ROOT/emulator/emulator" ]; then
+            echo "🔧 Эмулятор не найден, устанавливаем..."
+            yes | sdkmanager --install "emulator" || { echo "❌ ОШИБКА: Установка эмулятора не удалась"; exit 1; }
+          fi
+          
+          echo "🔧 Проверка наличия system-image..."
+          if ! sdkmanager --list | grep -q "system-images;android-34"; then
+            echo "🔧 System image не найден, устанавливаем..."
+            yes | sdkmanager --install "system-images;android-34;google_apis;x86_64" || { echo "❌ ОШИБКА: Установка system-image не удалась"; exit 1; }
+          fi
+          
+          echo "🔧 Создание AVD для кэширования..."
+          echo "no" | avdmanager create avd -n "cached-emulator" -k "system-images;android-34;google_apis;x86_64" || echo "⚠️ Не удалось создать AVD"
+          
+          echo "🔧 Проверка установки..."
+          ls -la $ANDROID_SDK_ROOT/emulator/emulator || echo "❌ emulator не найден"
+          sdkmanager --list | grep -E "emulator|system-images;android-34" || echo "⚠️ Компоненты эмулятора не найдены в списке"
+          avdmanager list avd || echo "⚠️ AVD не найдены"
+          
+          echo "✅ Эмулятор установлен и готов к кэшированию"
+        fi
 
     - name: 📦 Download APK artifact
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Add cache restoration and fallback Android SDK/emulator installation to `prepare-emulator` and `screenshots-phone` jobs.

The cached Android emulator was not consistently available across CI/CD jobs because `prepare-emulator` lacked cache restoration and both `prepare-emulator` and `screenshots-phone` needed fallback installation logic if the cache was missed.

---
<a href="https://cursor.com/background-agent?bcId=bc-edbbf487-30f5-46d1-8bd5-14726d8d52a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edbbf487-30f5-46d1-8bd5-14726d8d52a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>