### PR TITLE
Fix ui overlaps and improve text contrast

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/CharacterCreationActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/CharacterCreationActivity.kt
@@ -25,6 +25,12 @@ import android.widget.ImageView
 import android.widget.NumberPicker
 import android.speech.RecognizerIntent
 import android.content.ActivityNotFoundException
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.graphics.Typeface
+import android.text.TextUtils
 
 class CharacterCreationActivity : AppCompatActivity() {
     // Переменные для сбора данных персонажа
@@ -69,6 +75,33 @@ class CharacterCreationActivity : AppCompatActivity() {
         }
     }
 
+    private fun buildColoredParams(lines: List<Triple<String, Pair<String, Int>, Int>>): CharSequence {
+        // Triple: label, Pair(value, valueColor), labelColor
+        val builder = SpannableStringBuilder()
+        lines.forEachIndexed { index, triple ->
+            val label = triple.first
+            val value = triple.second.first
+            val valueColor = triple.second.second
+            val labelColor = triple.third
+
+            val startLabel = builder.length
+            builder.append(label)
+            val endLabel = builder.length
+            builder.setSpan(ForegroundColorSpan(labelColor), startLabel, endLabel, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+            builder.append(": ")
+
+            val startValue = builder.length
+            builder.append(value)
+            val endValue = builder.length
+            builder.setSpan(ForegroundColorSpan(valueColor), startValue, endValue, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            builder.setSpan(StyleSpan(Typeface.BOLD), startValue, endValue, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+            if (index != lines.lastIndex) builder.append("\n")
+        }
+        return builder
+    }
+
     private fun showProfessionStep() {
         val view = LayoutInflater.from(this).inflate(R.layout.step_profession, stepContainer, false)
         val stepTitle = view.findViewById<TextView>(R.id.tvStepTitle)
@@ -89,7 +122,23 @@ class CharacterCreationActivity : AppCompatActivity() {
             if (resId != 0) ivPhoto.setImageResource(resId)
             else ivPhoto.setImageResource(R.drawable.ic_profession_placeholder)
             tvName.text = prof.name
-            tvParams.text = "${prof.description}\nЗарплата: ${prof.salary}₽\nРасходы: ${prof.expenses}₽\nНалоги: ${prof.taxes}₽\nОбразование: ${prof.education}"
+
+            val labelColor = resources.getColor(R.color.text_secondary, null)
+            val salaryColor = resources.getColor(R.color.money_green, null)
+            val expenseColor = resources.getColor(R.color.expense_red, null)
+            val taxColor = resources.getColor(R.color.liability_orange, null)
+            val educationColor = resources.getColor(R.color.asset_blue, null)
+
+            val colored = buildColoredParams(
+                listOf(
+                    Triple("Зарплата", Pair("${prof.salary}₽", salaryColor), labelColor),
+                    Triple("Расходы", Pair("${prof.expenses}₽", expenseColor), labelColor),
+                    Triple("Налоги", Pair("${prof.taxes}₽", taxColor), labelColor),
+                    Triple("Образование", Pair(prof.education, educationColor), labelColor)
+                )
+            )
+            tvParams.text = TextUtils.concat(prof.description, "\n", colored)
+            tvParams.setLineSpacing(8f, 1f)
         }
         updateProfessionUI()
         btnLeft.setOnClickListener {
@@ -147,7 +196,21 @@ class CharacterCreationActivity : AppCompatActivity() {
             if (resId != 0) ivPhoto.setImageResource(resId)
             else ivPhoto.setImageResource(R.drawable.ic_dream_placeholder)
             tvName.text = dream.name
-            tvParams.text = "${dream.description}\nСтоимость: ${dream.cost}₽\nПассивный доход: ${dream.cashFlowRequired}₽\nЧисло на кубике: ${dream.fastTrackNumber}"
+
+            val labelColor = resources.getColor(R.color.text_secondary, null)
+            val costColor = resources.getColor(R.color.expense_red, null)
+            val incomeColor = resources.getColor(R.color.money_green, null)
+            val diceColor = resources.getColor(R.color.asset_blue, null)
+
+            val colored = buildColoredParams(
+                listOf(
+                    Triple("Стоимость", Pair("${dream.cost}₽", costColor), labelColor),
+                    Triple("Пассивный доход", Pair("${dream.cashFlowRequired}₽", incomeColor), labelColor),
+                    Triple("Число на кубике", Pair(dream.fastTrackNumber.toString(), diceColor), labelColor)
+                )
+            )
+            tvParams.text = colored
+            tvParams.setLineSpacing(8f, 1f)
         }
         updateDreamUI()
         btnLeft.setOnClickListener {

--- a/app/src/main/res/layout/step_dream.xml
+++ b/app/src/main/res/layout/step_dream.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:background="@color/background_color">
 
     <TextView
@@ -12,53 +13,75 @@
         android:textSize="28sp"
         android:textStyle="bold"
         android:textColor="@color/primary_color"
-        android:layout_gravity="top|center_horizontal"
-        android:layout_marginTop="48dp" />
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="48dp"
+        android:layout_marginBottom="16dp" />
 
-    <!-- Карточка мечты -->
-    <LinearLayout
-        android:id="@+id/dreamCard"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="500dp"
-        android:orientation="vertical"
-        android:background="@drawable/card_bg"
-        android:layout_gravity="center"
-        android:elevation="8dp"
-        android:padding="32dp"
-        android:gravity="center_horizontal">
-        <ImageView
-            android:id="@+id/ivDreamPhoto"
-            android:layout_width="220dp"
-            android:layout_height="220dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/ic_dream_placeholder" />
-        <TextView
-            android:id="@+id/tvDreamName"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Мечта"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:layout_marginTop="24dp"
-            android:textColor="@color/asset_blue" />
-        <TextView
-            android:id="@+id/tvDreamParams"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Параметры мечты"
-            android:textSize="18sp"
-            android:layout_marginTop="12dp"
-            android:textColor="@color/asset_blue" />
-    </LinearLayout>
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
 
-    <!-- Кнопки свайпа -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:paddingBottom="16dp">
+
+            <!-- Карточка мечты -->
+            <LinearLayout
+                android:id="@+id/dreamCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/card_bg"
+                android:elevation="8dp"
+                android:padding="24dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="center_horizontal">
+
+                <ImageView
+                    android:id="@+id/ivDreamPhoto"
+                    android:layout_width="220dp"
+                    android:layout_height="220dp"
+                    android:adjustViewBounds="true"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dream_placeholder" />
+
+                <TextView
+                    android:id="@+id/tvDreamName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Мечта"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:layout_marginTop="24dp"
+                    android:textColor="@color/asset_blue" />
+
+                <TextView
+                    android:id="@+id/tvDreamParams"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Параметры мечты"
+                    android:textSize="18sp"
+                    android:layout_marginTop="12dp"
+                    android:textColor="@color/text_primary" />
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+
+    <!-- Кнопки навигации снизу -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center"
-        android:layout_gravity="bottom"
-        android:layout_marginBottom="64dp">
+        android:paddingTop="8dp"
+        android:paddingBottom="24dp">
+
         <Button
             android:id="@+id/btnSwipeLeft"
             android:layout_width="80dp"
@@ -66,6 +89,7 @@
             android:text="⟵"
             android:textSize="32sp"
             android:background="@drawable/btn_circle_bg" />
+
         <Button
             android:id="@+id/btnChooseDream"
             android:layout_width="120dp"
@@ -75,6 +99,7 @@
             android:background="@drawable/btn_primary_bg"
             android:layout_marginStart="24dp"
             android:layout_marginEnd="24dp" />
+
         <Button
             android:id="@+id/btnSwipeRight"
             android:layout_width="80dp"
@@ -83,4 +108,4 @@
             android:textSize="32sp"
             android:background="@drawable/btn_circle_bg" />
     </LinearLayout>
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/step_profession.xml
+++ b/app/src/main/res/layout/step_profession.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:background="@color/background_color">
 
     <TextView
@@ -12,53 +13,76 @@
         android:textSize="28sp"
         android:textStyle="bold"
         android:textColor="@color/primary_color"
-        android:layout_gravity="top|center_horizontal"
-        android:layout_marginTop="48dp" />
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="48dp"
+        android:layout_marginBottom="16dp" />
 
-    <!-- Карточка профессии -->
-    <LinearLayout
-        android:id="@+id/professionCard"
+    <!-- Прокручиваемая область для карточки, чтобы не перекрывать кнопки -->
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="500dp"
-        android:orientation="vertical"
-        android:background="@drawable/card_bg"
-        android:layout_gravity="center"
-        android:elevation="8dp"
-        android:padding="32dp"
-        android:gravity="center_horizontal">
-        <ImageView
-            android:id="@+id/ivProfessionPhoto"
-            android:layout_width="220dp"
-            android:layout_height="220dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/ic_profession_placeholder" />
-        <TextView
-            android:id="@+id/tvProfessionName"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Профессия"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:layout_marginTop="24dp"
-            android:textColor="@color/asset_blue" />
-        <TextView
-            android:id="@+id/tvProfessionParams"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Параметры профессии"
-            android:textSize="18sp"
-            android:layout_marginTop="12dp"
-            android:textColor="@color/asset_blue" />
-    </LinearLayout>
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
 
-    <!-- Кнопки свайпа -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:paddingBottom="16dp">
+
+            <!-- Карточка профессии -->
+            <LinearLayout
+                android:id="@+id/professionCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/card_bg"
+                android:elevation="8dp"
+                android:padding="24dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="center_horizontal">
+
+                <ImageView
+                    android:id="@+id/ivProfessionPhoto"
+                    android:layout_width="220dp"
+                    android:layout_height="220dp"
+                    android:adjustViewBounds="true"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_profession_placeholder" />
+
+                <TextView
+                    android:id="@+id/tvProfessionName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Профессия"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:layout_marginTop="24dp"
+                    android:textColor="@color/asset_blue" />
+
+                <TextView
+                    android:id="@+id/tvProfessionParams"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Параметры профессии"
+                    android:textSize="18sp"
+                    android:layout_marginTop="12dp"
+                    android:textColor="@color/text_primary" />
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+
+    <!-- Кнопки навигации снизу -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center"
-        android:layout_gravity="bottom"
-        android:layout_marginBottom="64dp">
+        android:paddingTop="8dp"
+        android:paddingBottom="24dp">
+
         <Button
             android:id="@+id/btnSwipeLeft"
             android:layout_width="80dp"
@@ -66,6 +90,7 @@
             android:text="⟵"
             android:textSize="32sp"
             android:background="@drawable/btn_circle_bg" />
+
         <Button
             android:id="@+id/btnChooseProfession"
             android:layout_width="120dp"
@@ -75,6 +100,7 @@
             android:background="@drawable/btn_primary_bg"
             android:layout_marginStart="24dp"
             android:layout_marginEnd="24dp" />
+
         <Button
             android:id="@+id/btnSwipeRight"
             android:layout_width="80dp"
@@ -83,4 +109,4 @@
             android:textSize="32sp"
             android:background="@drawable/btn_circle_bg" />
     </LinearLayout>
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
Refactor profession and dream step layouts to prevent card overlap and apply distinct colors/bolding to parameter labels and values.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f1c1f93-addf-4e02-866e-4f52fc074d29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f1c1f93-addf-4e02-866e-4f52fc074d29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

