### PR TITLE
Adjust profession selection screen layout and fix swipe

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/CharacterCreationActivity.kt
+++ b/app/src/main/java/com/financialsuccess/game/CharacterCreationActivity.kt
@@ -170,6 +170,7 @@ class CharacterCreationActivity : AppCompatActivity() {
         val btnLeft = view.findViewById<Button>(R.id.btnSwipeLeft)
         val btnRight = view.findViewById<Button>(R.id.btnSwipeRight)
         val btnChoose = view.findViewById<Button>(R.id.btnChooseProfession)
+        val professionCard = view.findViewById<View>(R.id.professionCard)
 
         fun updateProfessionUI() {
             val prof = professions[professionIndex]
@@ -198,27 +199,21 @@ class CharacterCreationActivity : AppCompatActivity() {
             tvParams.setLineSpacing(8f, 1f)
         }
         updateProfessionUI()
-        btnLeft.setOnClickListener {
-            professionIndex = (professionIndex - 1 + professions.size) % professions.size
-            updateProfessionUI()
-            fadeOutSwipeHint(tvSwipeHint)
-        }
-        btnRight.setOnClickListener {
-            professionIndex = (professionIndex + 1) % professions.size
-            updateProfessionUI()
-            fadeOutSwipeHint(tvSwipeHint)
-        }
-        view.setOnTouchListener(object : View.OnTouchListener {
+        professionCard.setOnTouchListener(object : View.OnTouchListener {
             private var x1 = 0f
             private var x2 = 0f
             override fun onTouch(v: View?, event: android.view.MotionEvent?): Boolean {
                 when (event?.action) {
-                    android.view.MotionEvent.ACTION_DOWN -> x1 = event.x
+                    android.view.MotionEvent.ACTION_DOWN -> {
+                        x1 = event.x
+                        v?.parent?.requestDisallowInterceptTouchEvent(true)
+                    }
                     android.view.MotionEvent.ACTION_UP -> {
                         x2 = event.x
                         val deltaX = x2 - x1
                         if (deltaX > 100) btnLeft.performClick()
                         if (deltaX < -100) btnRight.performClick()
+                        v?.parent?.requestDisallowInterceptTouchEvent(false)
                     }
                 }
                 return true
@@ -246,6 +241,7 @@ class CharacterCreationActivity : AppCompatActivity() {
         val btnLeft = view.findViewById<Button>(R.id.btnSwipeLeft)
         val btnRight = view.findViewById<Button>(R.id.btnSwipeRight)
         val btnChoose = view.findViewById<Button>(R.id.btnChooseDream)
+        val dreamCard = view.findViewById<View>(R.id.dreamCard)
 
         fun updateDreamUI() {
             val dream = dreams[dreamIndex]
@@ -282,17 +278,21 @@ class CharacterCreationActivity : AppCompatActivity() {
             updateDreamUI()
             fadeOutSwipeHint(tvSwipeHint)
         }
-        view.setOnTouchListener(object : View.OnTouchListener {
+        dreamCard.setOnTouchListener(object : View.OnTouchListener {
             private var x1 = 0f
             private var x2 = 0f
             override fun onTouch(v: View?, event: android.view.MotionEvent?): Boolean {
                 when (event?.action) {
-                    android.view.MotionEvent.ACTION_DOWN -> x1 = event.x
+                    android.view.MotionEvent.ACTION_DOWN -> {
+                        x1 = event.x
+                        v?.parent?.requestDisallowInterceptTouchEvent(true)
+                    }
                     android.view.MotionEvent.ACTION_UP -> {
                         x2 = event.x
                         val deltaX = x2 - x1
                         if (deltaX > 100) btnLeft.performClick()
                         if (deltaX < -100) btnRight.performClick()
+                        v?.parent?.requestDisallowInterceptTouchEvent(false)
                     }
                 }
                 return true

--- a/app/src/main/res/layout/step_profession.xml
+++ b/app/src/main/res/layout/step_profession.xml
@@ -14,8 +14,8 @@
         android:textStyle="bold"
         android:textColor="@color/primary_color"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="48dp"
-        android:layout_marginBottom="16dp" />
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="12dp" />
 
     <!-- Прокручиваемая область для карточки, чтобы не перекрывать кнопки -->
     <ScrollView
@@ -29,7 +29,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
-            android:paddingBottom="16dp">
+            android:paddingBottom="8dp">
 
             <!-- Карточка профессии -->
             <LinearLayout
@@ -42,12 +42,13 @@
                 android:padding="24dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
-                android:gravity="center_horizontal">
+                android:gravity="center_horizontal"
+                android:clickable="true">
 
                 <ImageView
                     android:id="@+id/ivProfessionPhoto"
-                    android:layout_width="220dp"
-                    android:layout_height="220dp"
+                    android:layout_width="200dp"
+                    android:layout_height="200dp"
                     android:adjustViewBounds="true"
                     android:scaleType="centerCrop"
                     android:src="@drawable/ic_profession_placeholder" />
@@ -89,8 +90,8 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center"
-        android:paddingTop="8dp"
-        android:paddingBottom="24dp">
+        android:paddingTop="4dp"
+        android:paddingBottom="12dp">
 
         <Button
             android:id="@+id/btnSwipeLeft"


### PR DESCRIPTION
Optimizes layout on profession/dream selection screens to prevent scrolling and enables swipe gestures on cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-03dbc6d2-348d-427d-a88f-9ce4e928b2ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03dbc6d2-348d-427d-a88f-9ce4e928b2ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

