### PR TITLE
Fix birthday age increment bug

### DIFF
--- a/app/src/main/java/com/financialsuccess/game/GameManager.kt
+++ b/app/src/main/java/com/financialsuccess/game/GameManager.kt
@@ -81,6 +81,34 @@ class GameManager {
             currentState.player.passMonth()
         }
 
+        // Проверяем наступление дня рождения относительно текущей симулированной даты
+        run {
+            val player = currentState.player
+            val startDateMillis = player.startDateMillis
+            val nextAgeChangeMillis = player.nextAgeChangeMillis
+            if (startDateMillis != null && nextAgeChangeMillis != null) {
+                val cal = java.util.Calendar.getInstance().apply {
+                    timeInMillis = startDateMillis
+                    // Переносим календарь на текущий игровой месяц и день
+                    add(java.util.Calendar.MONTH, player.monthsPlayed)
+                    set(java.util.Calendar.DAY_OF_MONTH, player.currentDayOfMonth)
+                    set(java.util.Calendar.HOUR_OF_DAY, 0)
+                    set(java.util.Calendar.MINUTE, 0)
+                    set(java.util.Calendar.SECOND, 0)
+                    set(java.util.Calendar.MILLISECOND, 0)
+                }
+                if (cal.timeInMillis >= nextAgeChangeMillis) {
+                    player.age += 1
+                    // Сдвигаем следующую дату увеличения возраста ровно на 1 год вперёд
+                    val nb = java.util.Calendar.getInstance().apply {
+                        timeInMillis = nextAgeChangeMillis
+                        add(java.util.Calendar.YEAR, 1)
+                    }
+                    player.nextAgeChangeMillis = nb.timeInMillis
+                }
+            }
+        }
+
         // Если прошли полный круг (вернулись на старт)
         val passedStart = (oldPosition + steps) >= 24
         if (passedStart) {

--- a/app/src/main/java/com/financialsuccess/game/models/Player.kt
+++ b/app/src/main/java/com/financialsuccess/game/models/Player.kt
@@ -182,9 +182,11 @@ data class Player(
     fun passMonth() {
         monthsPlayed++
         currentDayOfMonth = 1
-        // Каждые 12 месяцев увеличиваем возраст на 1 год
-        if (monthsPlayed % 12 == 0) {
-            age++
+        // Увеличиваем возраст по упрощенному правилу только если нет данных о дате рождения
+        if (birthDateMillis == null || nextAgeChangeMillis == null) {
+            if (monthsPlayed % 12 == 0) {
+                age++
+            }
         }
     }
     


### PR DESCRIPTION
Fix age not incrementing on player's birthday by adjusting the age progression logic to check only day and month.

The previous implementation incremented age every 12 months, and the birthday-specific logic failed due to a full date (including year) comparison. This change ensures age increases precisely on the player's birthday (day and month) by comparing the current in-game date with `nextAgeChangeMillis`, and disables the generic 12-month increment when birthday data is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ff236a7-eff7-439e-93a7-d531dabdfa7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ff236a7-eff7-439e-93a7-d531dabdfa7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

